### PR TITLE
[topics/showcase rebase v2] Big prev/next images on permalink pages

### DIFF
--- a/www/src/components/share-menu.js
+++ b/www/src/components/share-menu.js
@@ -1,0 +1,146 @@
+import React, { Fragment } from "react"
+import MdShare from "react-icons/lib/md/share"
+import FaPinterestP from "react-icons/lib/fa/pinterest-p"
+import FaGooglePlus from "react-icons/lib/fa/google-plus"
+import FaLinkedin from "react-icons/lib/fa/linkedin"
+import FaFacebook from "react-icons/lib/fa/facebook"
+import FaTwitter from "react-icons/lib/fa/twitter"
+
+import presets, { colors } from "../utils/presets"
+import { rhythm } from "../utils/typography"
+
+const objectToParams = object =>
+  `?` +
+  Object.keys(object)
+    .filter(key => !!object[key])
+    .map(key => `${key}=${encodeURIComponent(object[key])}`)
+    .join(`&`)
+
+class ShareMenu extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      open: false,
+    }
+    this.shareMenu = this.shareMenu.bind(this)
+  }
+
+  shareMenu() {
+    const { open } = this.state
+    this.setState({
+      open: !open,
+    })
+  }
+
+  render() {
+    const { url, title, image } = this.props
+    const { open } = this.state
+    return (
+      <Fragment>
+        <button
+          onClick={this.shareMenu}
+          css={{
+            background: colors.gatsby,
+            border: 0,
+            borderRadius: presets.radius,
+            color: `#fff`,
+            cursor: `pointer`,
+          }}
+        >
+          <MdShare />
+        </button>
+        {open && (
+          <div
+            css={{
+              position: `absolute`,
+              top: 44,
+              left: `auto`,
+              right: 0,
+            }}
+          >
+            <a
+              {...linkAttrs}
+              href={`https://pinterest.com/pin/create/button/${objectToParams({
+                url: url,
+                media: image,
+                description: title,
+              })}`}
+              title="Share on Pinterest'"
+            >
+              <FaPinterestP />
+            </a>
+            <a
+              {...linkAttrs}
+              href={`https://www.linkedin.com/shareArticle${objectToParams({
+                mini: `true`,
+                url: url,
+                title: title,
+              })}`}
+              title="Share on LinkedIn"
+            >
+              <FaLinkedin />
+            </a>
+            <a
+              {...linkAttrs}
+              href={`https://www.facebook.com/sharer.php${objectToParams({
+                u: url,
+                t: title,
+              })}`}
+              title="Share on Facebook"
+            >
+              <FaFacebook />
+            </a>
+            <a
+              {...linkAttrs}
+              href={`https://plus.google.com/share${objectToParams({
+                url: url,
+              })}`}
+              title="Share on Google Plus"
+            >
+              <FaGooglePlus />
+            </a>
+            <a
+              {...linkAttrs}
+              href={`https://twitter.com/share${objectToParams({
+                url: url,
+                text: title,
+              })}`}
+              title="Share on Twitter"
+            >
+              <FaTwitter />
+            </a>
+          </div>
+        )}
+      </Fragment>
+    )
+  }
+}
+
+export default ShareMenu
+
+const styles = {
+  shareMenuListItem: {
+    width: 32,
+    height: 32,
+    marginBottom: rhythm(1.5 / 4),
+    "&&": {
+      background: colors.gatsby,
+      border: 0,
+      borderRadius: presets.radius,
+      boxShadow: `none`,
+      color: `#fff`,
+      display: `flex`,
+      alignItems: `center`,
+      justifyContent: `center`,
+      "&:hover": {
+        background: colors.gatsby,
+      },
+    },
+  },
+}
+
+const linkAttrs = {
+  css: { ...styles.shareMenuListItem },
+  target: `_blank`,
+  rel: `noopener noreferrer`,
+}

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -525,7 +525,8 @@ class ShowcasePage extends Component {
     filters: new Set([]),
   }
 
-  onClickHandler = target => target.current
+  onClickHandler = target =>
+    target.current
       ? scrollToAnchor(target.current, () => {
           this.setState({ filters: new Set([`Featured`]) })
         })

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -719,75 +719,82 @@ class ShowcasePage extends Component {
                   </div>
                 </Link>
               ))}
-              <a
-                href="#showcase"
+              <div
                 css={{
-                  ...styles.featuredSitesCard,
-                  textAlign: `center`,
-                  border: `1px solid ${hex2rgba(colors.lilac, 0.2)}`,
-                  borderRadius: presets.radius,
-                  "&&": {
-                    boxShadow: `none`,
-                    transition: `all ${presets.animation.speedDefault} ${
-                      presets.animation.curveDefault
-                    }`,
-                    "&:hover": {
-                      backgroundColor: hex2rgba(colors.ui.light, 0.25),
-                      transform: `translateY(-3px)`,
-                      boxShadow: `0 8px 20px ${hex2rgba(colors.lilac, 0.5)}`,
-                    },
-                  },
+                  display: `flex`,
                 }}
-                onClick={this.onClickHandler(this.showcase)}
               >
-                <div
+                <a
+                  href="#showcase"
                   css={{
-                    margin: rhythm(1),
-                    background: colors.ui.whisper,
-                    display: `flex`,
-                    alignItems: `center`,
-                    position: `relative`,
-                    flexBasis: `100%`,
+                    ...styles.featuredSitesCard,
+                    marginRight: `${rhythm(3 / 4)} !important`,
+                    border: `1px solid ${hex2rgba(colors.lilac, 0.2)}`,
+                    borderRadius: presets.radius,
+                    textAlign: `center`,
+                    "&&": {
+                      boxShadow: `none`,
+                      transition: `all ${presets.animation.speedDefault} ${
+                        presets.animation.curveDefault
+                      }`,
+                      "&:hover": {
+                        backgroundColor: hex2rgba(colors.ui.light, 0.25),
+                        transform: `translateY(-3px)`,
+                        boxShadow: `0 8px 20px ${hex2rgba(colors.lilac, 0.5)}`,
+                      },
+                    },
                   }}
+                  onClick={this.onClickHandler(this.showcase)}
                 >
-                  <img
-                    src={ShowcaseIcon}
+                  <div
                     css={{
-                      position: `absolute`,
-                      height: `100%`,
-                      width: `auto`,
-                      display: `block`,
-                      margin: `0`,
-                      opacity: 0.04,
-                    }}
-                    alt=""
-                  />
-                  <span
-                    css={{
-                      margin: `0 auto`,
-                      color: colors.gatsby,
+                      margin: rhythm(1),
+                      background: colors.ui.whisper,
+                      display: `flex`,
+                      alignItems: `center`,
+                      position: `relative`,
+                      flexBasis: `100%`,
                     }}
                   >
                     <img
                       src={ShowcaseIcon}
                       css={{
-                        height: 44,
+                        position: `absolute`,
+                        height: `100%`,
                         width: `auto`,
                         display: `block`,
-                        margin: `0 auto ${rhythm(options.blockMarginBottom)}`,
-                        [presets.Tablet]: {
-                          height: 64,
-                        },
-                        [presets.Hd]: {
-                          height: 72,
-                        },
+                        margin: `0`,
+                        opacity: 0.04,
                       }}
                       alt=""
                     />
-                    View all Featured Sites
-                  </span>
-                </div>
-              </a>
+                    <span
+                      css={{
+                        margin: `0 auto`,
+                        color: colors.gatsby,
+                      }}
+                    >
+                      <img
+                        src={ShowcaseIcon}
+                        css={{
+                          height: 44,
+                          width: `auto`,
+                          display: `block`,
+                          margin: `0 auto ${rhythm(options.blockMarginBottom)}`,
+                          [presets.Tablet]: {
+                            height: 64,
+                          },
+                          [presets.Hd]: {
+                            height: 72,
+                          },
+                        }}
+                        alt=""
+                      />
+                      View all Featured Sites
+                    </span>
+                  </div>
+                </a>
+              </div>
             </div>
             <div
               css={{
@@ -795,7 +802,7 @@ class ShowcasePage extends Component {
                 top: `0`,
                 bottom: rhythm(options.blockMarginBottom),
                 right: `-${rhythm(3 / 4)}`,
-                width: `60px`,
+                width: 60,
                 pointerEvents: `none`,
                 background: `linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(255,255,255,1) 100%)`,
               }}

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -70,6 +70,10 @@ const ShowcaseList = ({ items, count }) => {
         display: `flex`,
         flexWrap: `wrap`,
         padding: rhythm(3 / 4),
+        justifyContent: `center`,
+        [presets.Desktop]: {
+          justifyContent: `flex-start`,
+        },
       }}
     >
       {items.map(
@@ -398,18 +402,16 @@ class FilteredShowcase extends Component {
               display: `flex`,
               alignItems: `center`,
               flexDirection: `column`,
-              [presets.Desktop]: {
-                height: presets.headerHeight,
-                flexDirection: `row`,
-                alignItems: `center`,
-                ...styles.sticky,
-                background: `rgba(255,255,255,0.98)`,
-                paddingLeft: `${rhythm(3 / 4)}`,
-                paddingRight: `${rhythm(3 / 4)}`,
-                paddingBottom: rhythm(options.blockMarginBottom),
-                zIndex: 1,
-                borderBottom: `1px solid ${colors.ui.light}`,
-              },
+              height: presets.headerHeight,
+              flexDirection: `row`,
+              alignItems: `center`,
+              ...styles.sticky,
+              background: `rgba(255,255,255,0.98)`,
+              paddingLeft: `${rhythm(3 / 4)}`,
+              paddingRight: `${rhythm(3 / 4)}`,
+              paddingBottom: rhythm(options.blockMarginBottom),
+              zIndex: 1,
+              borderBottom: `1px solid ${colors.ui.light}`,
             }}
           >
             <h2
@@ -498,10 +500,15 @@ class FilteredShowcase extends Component {
             <button
               css={{
                 ...styles.button,
+                display: `block`,
                 marginBottom: rhythm(options.blockMarginBottom * 5),
-                marginLeft: rhythm(3 / 4),
-                marginRight: rhythm(3 / 4),
                 marginTop: rhythm(options.blockMarginBottom * 2),
+                marginLeft: `auto`,
+                marginRight: `auto`,
+                [presets.Desktop]: {
+                  marginLeft: rhythm(6 / 4),
+                  marginRight: rhythm(6 / 4),
+                },
               }}
               onClick={() => {
                 this.setState({ sitesToShow: this.state.sitesToShow + 15 })
@@ -568,10 +575,10 @@ class ShowcasePage extends Component {
           <div
             css={{
               marginBottom: rhythm(options.blockMarginBottom * 2),
-              [presets.Mobile]: {
-                display: `flex`,
-                alignItems: `center`,
-              },
+              display: `flex`,
+              alignItems: `center`,
+              flexWrap: `wrap`,
+              [presets.Mobile]: {},
             }}
           >
             <img src={FeaturedSitesIcon} alt="icon" css={{ marginBottom: 0 }} />
@@ -593,6 +600,10 @@ class ShowcasePage extends Component {
               href="#showcase"
               {...styles.withTitleHover}
               css={{
+                display: `none`,
+                [presets.Phablet]: {
+                  display: `block`,
+                },
                 "&&": {
                   ...scale(-1 / 6),
                   boxShadow: `none`,
@@ -943,7 +954,10 @@ const styles = {
   sticky: {
     paddingTop: rhythm(options.blockMarginBottom),
     position: `sticky`,
-    top: `calc(${presets.headerHeight} - 1px)`,
+    top: 0,
+    [presets.Desktop]: {
+      top: `calc(${presets.headerHeight} - 1px)`,
+    },
   },
   scrollbar: {
     WebkitOverflowScrolling: `touch`,

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -3,7 +3,7 @@ import Helmet from "react-helmet"
 
 import { Link } from "gatsby"
 import Img from "gatsby-image"
-// import { style } from "glamor"
+import { style } from "glamor"
 import hex2rgba from "hex2rgba"
 import MdFilterList from "react-icons/lib/md/filter-list"
 import FaAngleDown from "react-icons/lib/fa/angle-down"
@@ -79,6 +79,7 @@ const ShowcaseList = ({ items, count }) => {
             <Link
               key={node.id}
               to={{ pathname: node.fields.slug, state: { isModal: true } }}
+              {...styles.withTitleHover}
               css={{
                 margin: rhythm(3 / 4),
                 width: 280,
@@ -115,7 +116,9 @@ const ShowcaseList = ({ items, count }) => {
                   missing
                 </div>
               )}
-              {node.title}
+              <div>
+                <span className="title">{node.title}</span>
+              </div>
               <div
                 css={{
                   ...scale(-2 / 5),
@@ -588,6 +591,7 @@ class ShowcasePage extends Component {
             </h1>
             <a
               href="#showcase"
+              {...styles.withTitleHover}
               css={{
                 "&&": {
                   ...scale(-1 / 6),
@@ -605,7 +609,7 @@ class ShowcasePage extends Component {
               }}
               onClick={this.onClickHandler(this.showcase)}
             >
-              View all&nbsp;<MdArrowForward
+              <span className="title">View all</span>&nbsp;<MdArrowForward
                 style={{ marginLeft: 4, verticalAlign: `sub` }}
               />
             </a>
@@ -674,8 +678,9 @@ class ShowcasePage extends Component {
               {data.featured.edges.slice(0, 9).map(({ node }) => (
                 <Link
                   key={node.id}
+                  {...styles.featuredSitesCard}
+                  {...styles.withTitleHover}
                   css={{
-                    ...styles.featuredSitesCard,
                     "&&": {
                       borderBottom: `none`,
                       boxShadow: `none`,
@@ -702,7 +707,9 @@ class ShowcasePage extends Component {
                       }}
                     />
                   )}
-                  {node.title}
+                  <div>
+                    <span className="title">{node.title}</span>
+                  </div>
                   <div
                     css={{
                       ...scale(-1 / 6),
@@ -727,8 +734,8 @@ class ShowcasePage extends Component {
               >
                 <a
                   href="#showcase"
+                  {...styles.featuredSitesCard}
                   css={{
-                    ...styles.featuredSitesCard,
                     marginRight: `${rhythm(3 / 4)} !important`,
                     border: `1px solid ${hex2rgba(colors.lilac, 0.2)}`,
                     borderRadius: presets.radius,
@@ -886,7 +893,7 @@ export const showcaseQuery = graphql`
 `
 
 const styles = {
-  featuredSitesCard: {
+  featuredSitesCard: style({
     display: `flex`,
     flexDirection: `column`,
     flexGrow: 0,
@@ -901,7 +908,16 @@ const styles = {
     [presets.VHd]: {
       width: 400,
     },
-  },
+  }),
+  withTitleHover: style({
+    "& .title": {
+      transition: `box-shadow .3s cubic-bezier(.4,0,.2,1), transform .3s cubic-bezier(.4,0,.2,1)`,
+      boxShadow: `inset 0 0px 0px 0px ${colors.ui.whisper}`,
+    },
+    "&:hover .title": {
+      boxShadow: `inset 0 -3px 0px 0px ${colors.ui.bright}`,
+    },
+  }),
   button: {
     border: 0,
     borderRadius: presets.radius,

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -5,13 +5,6 @@ import { Link } from "gatsby"
 import Img from "gatsby-image"
 // import { style } from "glamor"
 import hex2rgba from "hex2rgba"
-
-import Layout from "../components/layout"
-import SearchIcon from "../components/search-icon"
-//import FuturaParagraph from "../components/futura-paragraph"
-//import Container from "../components/container"
-import { options, /* rhythm, */ scale, rhythm } from "../utils/typography"
-import presets, { colors } from "../utils/presets"
 import MdFilterList from "react-icons/lib/md/filter-list"
 import FaAngleDown from "react-icons/lib/fa/angle-down"
 import FaAngleUp from "react-icons/lib/fa/angle-up"
@@ -20,6 +13,14 @@ import MdCheckboxBlank from "react-icons/lib/md/check-box-outline-blank"
 import MdCheckbox from "react-icons/lib/md/check-box"
 import MdArrowDownward from "react-icons/lib/md/arrow-downward"
 import MdArrowForward from "react-icons/lib/md/arrow-forward"
+
+import Layout from "../components/layout"
+import SearchIcon from "../components/search-icon"
+//import FuturaParagraph from "../components/futura-paragraph"
+//import Container from "../components/container"
+import { options, /* rhythm, */ scale, rhythm } from "../utils/typography"
+import presets, { colors } from "../utils/presets"
+import scrollToAnchor from "../utils/scroll-to-anchor"
 
 import Fuse from "fuse.js"
 import FeaturedSitesIcon from "../assets/featured-sites-icons.svg"
@@ -407,7 +408,6 @@ class FilteredShowcase extends Component {
                 borderBottom: `1px solid ${colors.ui.light}`,
               },
             }}
-            id="search-heading"
           >
             <h2
               css={{
@@ -515,9 +515,21 @@ class FilteredShowcase extends Component {
 }
 
 class ShowcasePage extends Component {
+  constructor(props) {
+    super(props)
+    this.showcase = React.createRef()
+    this.onClickHandler = this.onClickHandler.bind(this)
+  }
+
   state = {
     filters: new Set([]),
   }
+
+  onClickHandler = target => target.current
+      ? scrollToAnchor(target.current, () => {
+          this.setState({ filters: new Set([`Featured`]) })
+        })
+      : () => {}
 
   render() {
     const data = this.props.data
@@ -574,7 +586,7 @@ class ShowcasePage extends Component {
               Featured Sites
             </h1>
             <a
-              href="#search-heading"
+              href="#showcase"
               css={{
                 "&&": {
                   ...scale(-1 / 6),
@@ -590,7 +602,7 @@ class ShowcasePage extends Component {
                   },
                 },
               }}
-              onClick={() => this.setState({ filters: new Set([`Featured`]) })}
+              onClick={this.onClickHandler(this.showcase)}
             >
               View all&nbsp;<MdArrowForward
                 style={{ marginLeft: 4, verticalAlign: `sub` }}
@@ -708,7 +720,7 @@ class ShowcasePage extends Component {
                 </Link>
               ))}
               <a
-                href="#search-heading"
+                href="#showcase"
                 css={{
                   ...styles.featuredSitesCard,
                   textAlign: `center`,
@@ -726,9 +738,7 @@ class ShowcasePage extends Component {
                     },
                   },
                 }}
-                onClick={() => {
-                  this.setState({ filters: new Set([`Featured`]) })
-                }}
+                onClick={this.onClickHandler(this.showcase)}
               >
                 <div
                   css={{
@@ -792,6 +802,11 @@ class ShowcasePage extends Component {
             />
           </div>
         </section>
+        <div
+          id="showcase"
+          css={{ position: `relative`, top: presets.headerHeight, height: 1 }}
+          ref={this.showcase}
+        />
         <FilteredShowcase
           data={data}
           filters={this.state.filters}

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -819,7 +819,11 @@ class ShowcasePage extends Component {
         </section>
         <div
           id="showcase"
-          css={{ position: `relative`, top: presets.headerHeight, height: 1 }}
+          css={{
+            position: `relative`,
+            top: `calc(-${presets.headerHeight} + 1px)`,
+            height: 1,
+          }}
           ref={this.showcase}
         />
         <FilteredShowcase

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -547,8 +547,8 @@ const styles = {
     color: colors.lilac,
     fontFamily: options.headerFontFamily.join(`,`),
     position: `absolute`,
-    top: `280px`,
-    width: `300px`,
+    top: 280,
+    width: 300,
     transform: `translateX(-75px) rotate(90deg)`,
     [presets.Desktop]: {
       ...scale(-1 / 6),
@@ -560,7 +560,7 @@ const styles = {
   },
   prevNextImage: {
     borderRadius: presets.radius,
-    boxShadow: `0px 0px 38px -8px ${colors.gatsby}`,
+    boxShadow: `0 0 38px -8px ${colors.gatsby}`,
   },
   prevNextPermalinkLabel: {
     color: colors.gray.calm,

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -207,6 +207,20 @@ class ShowcaseTemplate extends React.Component {
           >
             <Helmet>
               <title>{data.sitesYaml.title}</title>
+              <meta
+                name="og:image"
+                content={`https://gatsbyjs.org${
+                  data.sitesYaml.childScreenshot.screenshotFile.childImageSharp
+                    .resize.src
+                }`}
+              />
+              <meta
+                name="twitter:image"
+                content={`https://gatsbyjs.org${
+                  data.sitesYaml.childScreenshot.screenshotFile.childImageSharp
+                    .resize.src
+                }`}
+              />
             </Helmet>
             <div
               css={{
@@ -497,6 +511,14 @@ export const pageQuery = graphql`
             }
             sizes(maxWidth: 700) {
               ...GatsbyImageSharpSizes
+            }
+            resize(
+              width: 1500
+              height: 1500
+              cropFocus: CENTER
+              toFormat: JPG
+            ) {
+              src
             }
           }
         }

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -341,20 +341,19 @@ class ShowcaseTemplate extends React.Component {
               <a
                 href={data.sitesYaml.main_url}
                 css={{
+                  border: 0,
+                  borderRadius: presets.radius,
                   color: colors.gatsby,
                   fontFamily: options.headerFontFamily.join(`,`),
+                  fontWeight: `bold`,
                   left: `auto`,
+                  padding: `${rhythm(1 / 5)} ${rhythm(2 / 3)}`,
                   position: `absolute`,
                   right: gutter,
                   top: gutter,
-                  zIndex: 1,
                   textDecoration: `none`,
-                  border: 0,
-                  borderRadius: presets.radius,
-                  fontFamily: options.headerFontFamily.join(`,`),
-                  fontWeight: `bold`,
-                  padding: `${rhythm(1 / 5)} ${rhythm(2 / 3)}`,
                   WebkitFontSmoothing: `antialiased`,
+                  zIndex: 1,
                   "&&": {
                     backgroundColor: colors.gatsby,
                     borderBottom: `none`,

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -7,6 +7,7 @@ import presets, { colors } from "../utils/presets"
 import { options, scale, rhythm } from "../utils/typography"
 import { navigateTo, Link } from "gatsby"
 import Layout from "../components/layout"
+import ShareMenu from "../components/share-menu"
 
 import Img from "gatsby-image"
 
@@ -354,35 +355,50 @@ class ShowcaseTemplate extends React.Component {
                 position: `relative`,
               }}
             >
-              <a
-                href={data.sitesYaml.main_url}
+              <div
                 css={{
-                  border: 0,
-                  borderRadius: presets.radius,
-                  color: colors.gatsby,
-                  fontFamily: options.headerFontFamily.join(`,`),
-                  fontWeight: `bold`,
-                  left: `auto`,
-                  padding: `${rhythm(1 / 5)} ${rhythm(2 / 3)}`,
                   position: `absolute`,
                   right: gutter,
                   top: gutter,
-                  textDecoration: `none`,
-                  WebkitFontSmoothing: `antialiased`,
+                  left: `auto`,
                   zIndex: 1,
-                  "&&": {
-                    backgroundColor: colors.gatsby,
-                    borderBottom: `none`,
-                    boxShadow: `none`,
-                    color: `white`,
-                    "&:hover": {
-                      backgroundColor: colors.gatsby,
-                    },
-                  },
+                  display: `flex`,
                 }}
               >
-                <MdLaunch style={{ verticalAlign: `sub` }} /> Visit site
-              </a>
+                <a
+                  href={data.sitesYaml.main_url}
+                  css={{
+                    border: 0,
+                    borderRadius: presets.radius,
+                    color: colors.gatsby,
+                    fontFamily: options.headerFontFamily.join(`,`),
+                    fontWeight: `bold`,
+                    marginRight: rhythm(3 / 4),
+                    padding: `${rhythm(1 / 5)} ${rhythm(2 / 3)}`,
+                    textDecoration: `none`,
+                    WebkitFontSmoothing: `antialiased`,
+                    "&&": {
+                      backgroundColor: colors.gatsby,
+                      borderBottom: `none`,
+                      boxShadow: `none`,
+                      color: `white`,
+                      "&:hover": {
+                        backgroundColor: colors.gatsby,
+                      },
+                    },
+                  }}
+                >
+                  <MdLaunch style={{ verticalAlign: `sub` }} /> Visit site
+                </a>
+                <ShareMenu
+                  url={data.sitesYaml.main_url}
+                  title={data.sitesYaml.title}
+                  image={`https://gatsbyjs.org${
+                    data.sitesYaml.childScreenshot.screenshotFile
+                      .childImageSharp.resize.src
+                  }`}
+                />
+              </div>
               <Img
                 sizes={
                   data.sitesYaml.childScreenshot.screenshotFile.childImageSharp

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -11,6 +11,8 @@ import Layout from "../components/layout"
 import Img from "gatsby-image"
 
 import MdArrowUpward from "react-icons/lib/md/arrow-upward"
+import MdArrowForward from "react-icons/lib/md/arrow-forward"
+import MdArrowBack from "react-icons/lib/md/arrow-back"
 import MdLaunch from "react-icons/lib/md/launch"
 import FeaturedIcon from "../assets/featured-detailpage-featuredicon.svg"
 import FeatherIcon from "../assets/showcase-feather.svg"
@@ -415,7 +417,6 @@ class ShowcaseTemplate extends React.Component {
 
 export default ShowcaseTemplate
 
-// TODO: the image dimensions here are 100x100, but the design calls for much larger. do we do it?
 class PermalinkPageFooter extends React.Component {
   state = {
     windowWidth: null,
@@ -432,9 +433,8 @@ class PermalinkPageFooter extends React.Component {
     return (
       <div
         css={{
-          display: `flex`,
           borderTop: `1px solid ${colors.ui.light}`,
-          padding: 50,
+          display: `flex`,
           paddingTop: 15,
         }}
       >
@@ -446,17 +446,12 @@ class PermalinkPageFooter extends React.Component {
               state: { isModal: false },
             }}
           >
-            ← {previousSite.title}
+            <MdArrowBack style={{ marginRight: 4, verticalAlign: `sub` }} />
+            {previousSite.title}
           </Link>
           <Img
-            css={{
-              boxShadow: `0px 0px 38px -8px ${colors.gatsby}`,
-              width: `100%`,
-              height: `100%`,
-            }}
-            resolutions={
-              previousSite.childScreenshot.screenshotFile.childImageSharp
-                .resolutions
+            sizes={
+              previousSite.childScreenshot.screenshotFile.childImageSharp.sizes
             }
             alt=""
           />
@@ -466,17 +461,13 @@ class PermalinkPageFooter extends React.Component {
           <Link
             to={{ pathname: nextSite.fields.slug, state: { isModal: false } }}
           >
-            {nextSite.title} →
+            {nextSite.title}&nbsp;<MdArrowForward
+              style={{ marginLeft: 4, verticalAlign: `sub` }}
+            />
           </Link>
           <Img
-            css={{
-              boxShadow: `0px 0px 38px -8px ${colors.gatsby}`,
-              width: `100%`,
-              height: `100%`,
-            }}
-            resolutions={
-              nextSite.childScreenshot.screenshotFile.childImageSharp
-                .resolutions
+            sizes={
+              nextSite.childScreenshot.screenshotFile.childImageSharp.sizes
             }
             alt=""
           />
@@ -527,6 +518,9 @@ export const pageQuery = graphql`
               childImageSharp {
                 resolutions(width: 100, height: 100) {
                   ...GatsbyImageSharpResolutions
+                }
+                sizes(maxWidth: 800) {
+                  ...GatsbyImageSharpSizes
                 }
               }
             }

--- a/www/src/utils/scroll-to-anchor.js
+++ b/www/src/utils/scroll-to-anchor.js
@@ -1,0 +1,78 @@
+// courtesy of @jlengstorf, found at
+// https://github.com/jlengstorf/marisamorby.com/blob/f16e4165ba67ae096d907e1cfa477664a2f7e81f/src/utils/scroll-to-anchor.js
+
+/**
+ * Browser workaround to avoid a bug where scrollTop doesn’t work.
+ * @return {Element}  the scrollable root element
+ */
+const getScrollableElement = () =>
+  document.body.scrollTop ? document.body : document.documentElement
+
+/**
+ * Easing, using sinusoidal math (or some shit).
+ *
+ * I know; this makes my head hurt, too. Math is hard. This formula was copied
+ * (I reformatted for legibility) from here: <http://gizma.com/easing/#sin3>
+ *
+ * @param  {Number} elapsed how much time has elapsed already
+ * @param  {Number} start   the starting position
+ * @param  {Number} change  the desired step size
+ * @param  {Number} length  the duration length
+ * @return {Number}         the new position based on the easing formula
+ */
+const easeInOutSine = (elapsed, start, change, length) =>
+  -change / 2 * (Math.cos(Math.PI * elapsed / length) - 1) + start
+
+// Sets up a loop that executes for the length of time set in duration
+const animateScroll = (
+  element,
+  elapsedTime,
+  { position, stepSize, increment, duration, callback = () => {} }
+) => {
+  const nextTime = elapsedTime + increment
+
+  // Set the new element position using an easing formula.
+  // eslint-disable-next-line no-param-reassign
+  element.scrollTop = easeInOutSine(nextTime, position, stepSize, duration)
+
+  if (nextTime < duration) {
+    setTimeout(() => {
+      animateScroll(element, nextTime, {
+        position,
+        stepSize,
+        increment,
+        duration,
+        callback,
+      })
+    }, increment)
+  } else {
+    callback()
+  }
+}
+
+const scrollToLocation = (element, targetPos, duration, callback) =>
+  new Promise(resolve => {
+    animateScroll(element, 0, {
+      position: element.scrollTop,
+      stepSize: targetPos - element.scrollTop,
+      increment: 20,
+      callback: () => {
+        callback()
+        resolve()
+      },
+      duration,
+    })
+  })
+
+const scrollToAnchor = (target, callback) => event => {
+  event.preventDefault()
+  const rootElement = getScrollableElement()
+  const targetOffset = target.offsetTop
+  console.log(rootElement)
+  console.log(target)
+  console.log(targetOffset)
+
+  scrollToLocation(rootElement, targetOffset, 750, callback)
+}
+
+export default scrollToAnchor


### PR DESCRIPTION
Along the way:

* Ensure first row of cards being fully visible when jumping to `#search-heading` (now `#showcase`) via clicking the _Featured Site_'s "View all"-button or the corresponding card in the "Featured Sites" horizontal scroller. Also threw in `scroll-to-anchor.js` for those links, courtesy of @jlengstorf 🙏, found at https://github.com/jlengstorf/marisamorby.com/blob/f16e4165ba67ae096d907e1cfa477664a2f7e81f/src/utils/scroll-to-anchor.js.
* Underline title of card when hovering the latter.

Won't do more tonight so this is GTG ;-)