### PR TITLE
[topics/showcase rebase v2] Weekend PR :D

### DIFF
--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -554,6 +554,10 @@ class ShowcasePage extends Component {
           css={{
             margin: `${rhythm(options.blockMarginBottom)} ${rhythm(3 / 4)} 0`,
             position: `relative`,
+            display: "none",
+            [presets.Desktop]: {
+              display: "block"
+            }
           }}
         >
           <div

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -647,9 +647,8 @@ class ShowcasePage extends Component {
               >
                 Want to get featured?
               </div>
-              {/* TODO: maybe have a site submission issue template */}
               <a
-                href="https://github.com/gatsbyjs/gatsby/issues/new?template=feature_request.md"
+                href="https://next.gatsbyjs.org/docs/site-showcase-submissions/"
                 target="_blank"
                 rel="noopener noreferrer"
                 css={{

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -401,10 +401,8 @@ class FilteredShowcase extends Component {
             css={{
               display: `flex`,
               alignItems: `center`,
-              flexDirection: `column`,
               height: presets.headerHeight,
               flexDirection: `row`,
-              alignItems: `center`,
               ...styles.sticky,
               background: `rgba(255,255,255,0.98)`,
               paddingLeft: `${rhythm(3 / 4)}`,

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -472,40 +472,55 @@ class PermalinkPageFooter extends React.Component {
           },
         }}
       >
-        <div css={{ flex: 1 }}>
-          <div css={{ ...styles.prevNextPermalinkLabel }}>Previous</div>
+        <div css={{ ...styles.prevNextPermalinkContainer }}>
           <Link
             to={{
               pathname: previousSite.fields.slug,
               state: { isModal: false },
             }}
           >
-            <MdArrowBack style={{ marginRight: 4, verticalAlign: `sub` }} />
-            {previousSite.title}
+            <div css={{ ...styles.prevNextPermalinkMeta }}>
+              <div css={{ ...styles.prevNextPermalinkMetaInner }}>
+                <div css={{ ...styles.prevNextPermalinkLabel }}>Previous</div>
+                <div css={{ ...styles.prevNextPermalinkTitle }}>
+                  <MdArrowBack style={{ ...styles.prevNextPermalinkArrow }} />
+                  <span css={{ ...styles.truncate }}>{previousSite.title}</span>
+                </div>
+              </div>
+            </div>
             <Img
               sizes={
                 previousSite.childScreenshot.screenshotFile.childImageSharp
                   .sizes
               }
               alt=""
+              style={{ ...styles.prevNextPermalinkImage }}
             />
           </Link>
         </div>
-        <div css={{ flex: 1 }}>
-          <div css={{ ...styles.prevNextPermalinkLabel }}>Next</div>
+        <div css={{ ...styles.prevNextPermalinkContainer }}>
           <Link
             to={{ pathname: nextSite.fields.slug, state: { isModal: false } }}
           >
-            {nextSite.title}&nbsp;<MdArrowForward
-              style={{ marginLeft: 4, verticalAlign: `sub` }}
-            />
+            <div
+              css={{
+                marginLeft: rhythm(6 / 4),
+                marginRight: rhythm(6 / 4),
+              }}
+            >
+              <div css={{ ...styles.prevNextPermalinkLabel }}>Next</div>
+              <div css={{ ...styles.prevNextPermalinkTitle }}>
+                <span css={{ ...styles.truncate }}>{nextSite.title}</span>
+                <MdArrowForward style={{ ...styles.prevNextPermalinkArrow }} />
+              </div>
+            </div>
             <Img
               sizes={
                 nextSite.childScreenshot.screenshotFile.childImageSharp.sizes
               }
               alt=""
               style={{
-                marginBottom: 0,
+                ...styles.prevNextPermalinkImage,
               }}
             />
           </Link>
@@ -604,5 +619,46 @@ const styles = {
   prevNextPermalinkLabel: {
     color: colors.gray.calm,
     fontFamily: options.headerFontFamily.join(`,`),
+    fontWeight: `normal`,
+  },
+  prevNextPermalinkImage: {
+    marginBottom: 0,
+    marginTop: rhythm(options.blockMarginBottom),
+  },
+  prevNextPermalinkTitle: {
+    color: colors.gatsby,
+    display: `block`,
+    position: `relative`,
+  },
+  prevNextPermalinkContainer: {
+    width: `50%`,
+  },
+  truncate: {
+    whiteSpace: `nowrap`,
+    overflow: `hidden`,
+    textOverflow: `ellipsis`,
+    display: `block`,
+    width: `100%`,
+  },
+  prevNextPermalinkArrow: {
+    color: colors.lilac,
+    marginRight: 4,
+    verticalAlign: `sub`,
+    position: `absolute`,
+    left: `-${rhythm(3 / 4)}`,
+    top: `50%`,
+    transform: `translateY(-50%)`,
+  },
+  prevNextPermalinkMeta: {
+    marginLeft: rhythm(6 / 4),
+    display: `flex`,
+    flexDirection: `row`,
+    justifyContent: `flex-end`,
+  },
+  prevNextPermalinkMetaInner: {
+    flexBasis: 540,
+    flexGrow: 0,
+    flexShrink: 1,
+    minWidth: 0,
   },
 }

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -558,7 +558,7 @@ export const pageQuery = graphql`
                 resolutions(width: 100, height: 100) {
                   ...GatsbyImageSharpResolutions
                 }
-                sizes(maxWidth: 800) {
+                sizes(maxWidth: 800, maxHeight: 800) {
                   ...GatsbyImageSharpSizes
                 }
               }

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -466,6 +466,10 @@ class PermalinkPageFooter extends React.Component {
           borderTop: `1px solid ${colors.ui.light}`,
           display: `flex`,
           paddingTop: rhythm(options.blockMarginBottom * 2),
+          paddingBottom: 58,
+          [presets.Tablet]: {
+            paddingBottom: 0,
+          },
         }}
       >
         <div css={{ flex: 1 }}>

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -373,7 +373,7 @@ class ShowcaseTemplate extends React.Component {
                     color: colors.gatsby,
                     fontFamily: options.headerFontFamily.join(`,`),
                     fontWeight: `bold`,
-                    marginRight: rhythm(3 / 4),
+                    marginRight: rhythm(1.5 / 4),
                     padding: `${rhythm(1 / 5)} ${rhythm(2 / 3)}`,
                     textDecoration: `none`,
                     WebkitFontSmoothing: `antialiased`,
@@ -465,7 +465,7 @@ class PermalinkPageFooter extends React.Component {
         css={{
           borderTop: `1px solid ${colors.ui.light}`,
           display: `flex`,
-          paddingTop: 15,
+          paddingTop: rhythm(options.blockMarginBottom * 2),
         }}
       >
         <div css={{ flex: 1 }}>

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -478,13 +478,14 @@ class PermalinkPageFooter extends React.Component {
           >
             <MdArrowBack style={{ marginRight: 4, verticalAlign: `sub` }} />
             {previousSite.title}
+            <Img
+              sizes={
+                previousSite.childScreenshot.screenshotFile.childImageSharp
+                  .sizes
+              }
+              alt=""
+            />
           </Link>
-          <Img
-            sizes={
-              previousSite.childScreenshot.screenshotFile.childImageSharp.sizes
-            }
-            alt=""
-          />
         </div>
         <div css={{ flex: 1 }}>
           <div css={{ ...styles.prevNextPermalinkLabel }}>Next</div>
@@ -494,13 +495,13 @@ class PermalinkPageFooter extends React.Component {
             {nextSite.title}&nbsp;<MdArrowForward
               style={{ marginLeft: 4, verticalAlign: `sub` }}
             />
+            <Img
+              sizes={
+                nextSite.childScreenshot.screenshotFile.childImageSharp.sizes
+              }
+              alt=""
+            />
           </Link>
-          <Img
-            sizes={
-              nextSite.childScreenshot.screenshotFile.childImageSharp.sizes
-            }
-            alt=""
-          />
         </div>
       </div>
     )

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -504,6 +504,9 @@ class PermalinkPageFooter extends React.Component {
                 nextSite.childScreenshot.screenshotFile.childImageSharp.sizes
               }
               alt=""
+              style={{
+                marginBottom: 0,
+              }}
             />
           </Link>
         </div>

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -284,7 +284,7 @@ class ShowcaseTemplate extends React.Component {
                 fontFamily: options.headerFontFamily.join(`,`),
                 margin: `0 ${gutter}`,
                 [presets.Desktop]: {
-                  margin: `0 ${gutter}px`,
+                  margin: `0 ${gutterDesktop}`,
                 },
               }}
             >


### PR DESCRIPTION
* add permalink page "previous/next" design (with a few pragmatic layout changes)
  * bring back square images for those links
  * ensure those images are not overlapped by the mobile navigation
* point "Submit your Site" href to https://next.gatsbyjs.org/docs/site-showcase-submissions/ (ref. https://github.com/gatsbyjs/gatsby/pull/5867)